### PR TITLE
Parse org parameter for install and upgrade

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -85,7 +85,7 @@ program
             return tasks.installChaincode(
                 name,
                 language,
-                cmd.org,
+                JSON.parse(cmd.org),
                 channel,
                 '1.0',
                 cmd.ctor,
@@ -114,7 +114,7 @@ program
             return tasks.upgradeChaincode(
                 name,
                 language,
-                cmd.org,
+                JSON.parse(cmd.org),
                 channel,
                 ver,
                 cmd.ctor,


### PR DESCRIPTION
org parameter is supposed to be an array of orgs, so it has to be passed as JSON string and parsed to string[].
currently you can only pass one org as string or leave out the parameter. leaving it out defaults to [org1, org2] which works with the default hutley network, but not with any other network topology.