### PR TITLE
escapes wildcard - related #163

### DIFF
--- a/src/generators/downloadFabricBinaries.ts
+++ b/src/generators/downloadFabricBinaries.ts
@@ -119,7 +119,7 @@ dockerFabricPull() {
     dockerThirdPartyImagesPull $THIRDPARTY_TAG
     echo
     echo "===> List out hyperledger docker images"
-    docker images | grep hyperledger*
+    docker images | grep 'hyperledger*'
 
   }
 


### PR DESCRIPTION
Simple fix related to a missing escape of a bash wildcard during docker images dowload checking.