### PR TITLE
Hyperledger issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/hurley",
-  "version": "1.1.2",
+  "version": "1.1.2-alpha.0b947e9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/command.ts
+++ b/src/command.ts
@@ -53,7 +53,7 @@ program
         if (cmd) {
             await tasks.createNetwork(
                 cmd.network,
-                !cmd.organizations || (cmd.organizations <= 2) ? 2 : cmd.organizations,
+                !cmd.organizations || (cmd.organizations <= 1) ? 1 : cmd.organizations,
                 !cmd.users || (cmd.users <= 1) ? 1 : cmd.users,
                 !cmd.channels || (cmd.channels <= 1) ? 1 : cmd.channels,
                 cmd.path, !!cmd.inside, !!cmd.skipDownload

--- a/src/generators/dockercompose.yaml.ts
+++ b/src/generators/dockercompose.yaml.ts
@@ -90,6 +90,7 @@ ${org.peers.map(peer => `
             - CORE_LOGGING_GOSSIP=DEBUG
             - CORE_LOGGING_GRPC=DEBUG
             - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
+            - CORE_CHAINCODE_BUILDER=hyperledger/fabric-ccenv:1.4.1
             - CORE_PEER_LOCALMSPID=${org.name}MSP
             - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@${org.name}.hurley.lab/msp
             - CORE_PEER_GOSSIP_SKIPHANDSHAKE=true


### PR DESCRIPTION
Hyperledger sunset the nexus URLs where Hurley used to download the binaries.
Also they removed the ccenv:latest tag, so we need to specify 1.4.1 explicitly now.
In Addition, a bug fix to allow single organizations instead of two (still the default)