### PR TITLE
feat: add hyperledger explorer option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/hurley",
-  "version": "1.1.5",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6074,9 +6074,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/hurley",
-  "version": "1.1.5",
+  "version": "1.2.1",
   "description": "The development environment toolset for enterprise blockchain projects",
   "main": "index.js",
   "files": [
@@ -63,6 +63,7 @@
     "fs-extra": "^7.0.1",
     "inquirer": "^2.0.0",
     "insight": "^0.10.1",
+    "js-yaml": "^3.14.0",
     "mem-fs": "^1.1.3",
     "mem-fs-editor": "^5.1.0",
     "mocha": "^5.2.0",

--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,9 @@ hurl invoke <chaincode> <fn>  [args...]
     [-u, --user <user>] # Select an specific user to execute command. Default user1
     [-o, --organization <organization>] # Select a specific organisation to execute the command. Default org1
     [-C --channel <channel>] # Defaults to ch1
+    [-e, --explorer] # Uses hyperledger explorer with default credential admin / admin
     [-i --inside] # Whether or not the `hurl` command will runs inside the same Docker network where the blockchain was provisioned
+    [--skip-download] # Skip downloading the Fabric Binaries and Docker images
 ```
 
 The main parameters here are `<chaincode>`, `<fn>`, and [args...] where [args...] is an array of params separated by a blank space, for example:

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,16 @@ hurl new
     [-i --inside] # Whether or not the `hurl` command will runs inside the same Docker network where the blockchain was provisioned
 ```
 
+### hurl explorer
+
+Brings up a hyperledger explorer instance, restart if there is a running one
+
+```bash
+# Runs hyperledger explorer
+hurl explorer
+    [-p --port <path-to-install-the-network>] # Port where explorer will run (default: "8080")
+```
+
 ### hurl clean
 
 Clear your environment from all the components.
@@ -123,7 +133,6 @@ hurl invoke <chaincode> <fn>  [args...]
     [-u, --user <user>] # Select an specific user to execute command. Default user1
     [-o, --organization <organization>] # Select a specific organisation to execute the command. Default org1
     [-C --channel <channel>] # Defaults to ch1
-    [-e, --explorer] # Uses hyperledger explorer with default credential admin / admin
     [-i --inside] # Whether or not the `hurl` command will runs inside the same Docker network where the blockchain was provisioned
     [--skip-download] # Skip downloading the Fabric Binaries and Docker images
 ```

--- a/src/command.ts
+++ b/src/command.ts
@@ -17,6 +17,9 @@ const tasks = {
         path?: string, explorer?:boolean, inside?: boolean, skipDownload?: boolean) {
         return await CLI.createNetwork(network, organizations, users, channels, path, explorer, inside, skipDownload);
     },
+    async startupExplorer(port: string){
+        return CLI.startupExplorer(port);
+    },
     async cleanNetwork(rmi: boolean) {
         return await CLI.cleanNetwork(rmi);
     },
@@ -63,6 +66,16 @@ program
             await tasks.createNetwork();
         }
     });
+
+
+program
+    .command('explorer')
+    .option('-p, --port <port>', 'Port where explorer will run','8080')
+    .action(async (cmd: any) => {
+        await tasks.startupExplorer(cmd.port); // if -R is not passed cmd.rmi is true
+    });
+
+
 program
     .command('clean')
     .option('-R, --no-rmi', 'Do not remove docker images')

--- a/src/command.ts
+++ b/src/command.ts
@@ -14,8 +14,8 @@ function collect(val, memo) {
 
 const tasks = {
     async createNetwork(network?: any, organizations?: string, users?: string, channels?: string,
-        path?: string, inside?: boolean, skipDownload?: boolean) {
-        return await CLI.createNetwork(network, organizations, users, channels, path, inside, skipDownload);
+        path?: string, explorer?:boolean, inside?: boolean, skipDownload?: boolean) {
+        return await CLI.createNetwork(network, organizations, users, channels, path, explorer, inside, skipDownload);
     },
     async cleanNetwork(rmi: boolean) {
         return await CLI.cleanNetwork(rmi);
@@ -46,6 +46,7 @@ program
     .option('-o, --organizations <organizations>', 'Amount of organizations')
     .option('-u, --users <users>', 'Users per organization')
     .option('-p, --path <path>', 'Path to deploy the network')
+    .option('-e, --explorer', 'Uses hyperledger explorer')
     .option('-i, --inside', 'Optimized for running inside the docker compose network')
     .option('--skip-download', 'Skip downloading the Fabric Binaries and Docker images')
     // .option('-p, --peers <peers>', 'Peers per organization')
@@ -56,7 +57,7 @@ program
                 !cmd.organizations || (cmd.organizations <= 1) ? 1 : cmd.organizations,
                 !cmd.users || (cmd.users <= 1) ? 1 : cmd.users,
                 !cmd.channels || (cmd.channels <= 1) ? 1 : cmd.channels,
-                cmd.path, !!cmd.inside, !!cmd.skipDownload
+                cmd.path, !!cmd.explorer ,!!cmd.inside, !!cmd.skipDownload
             );
         } else {
             await tasks.createNetwork();

--- a/src/generators/config.json.ts
+++ b/src/generators/config.json.ts
@@ -1,0 +1,20 @@
+import { BaseGenerator } from './base';
+import { join } from 'path';
+
+export class ConfigJsonGenerator extends BaseGenerator {
+    contents =`{
+          "network-configs": {
+            "hurley-network": {
+              "name": "hurley-network",
+              "profile": "./connection-profile/connection-profile.json"
+            }
+          },
+          "license": "Apache-2.0"
+        }
+  `;
+
+  constructor(filename: string, path: string) {
+    super(filename, path);
+    this.success = join(path, 'config.json.successful');
+  }
+}

--- a/src/generators/dockercompose.yaml.ts
+++ b/src/generators/dockercompose.yaml.ts
@@ -15,7 +15,7 @@ export class DockerComposeYamlOptions {
 }
 export class DockerComposeYamlGenerator extends BaseGenerator {
     success = join(this.path, 'dockercompose.yaml.successful');
-    constructor(filename: string, path: string, private options: DockerComposeYamlOptions) {
+    constructor(filename: string, path: string, public insideDocker: boolean, private options: DockerComposeYamlOptions) {
         super(filename, path);
     }
     async build() {
@@ -133,7 +133,7 @@ ${org.peers.map(peer => `
 
 `).join('')}
 `).join('')}
-      
+       
 volumes:
   shared:
 

--- a/src/generators/explorerConnectionProfile.ts
+++ b/src/generators/explorerConnectionProfile.ts
@@ -1,0 +1,77 @@
+// tslint:disable:max-line-length
+import { BaseGenerator } from './base';
+import { join } from 'path';
+import { Organization } from '../models/organization';
+import { readdirSync } from 'fs';
+
+export class ExplorerConnectionProfileJSONGeneratorOptions {
+    org: Organization;
+    networkRootPath: string;
+}
+export class ExplorerConnectionProfileJSONGenerator extends BaseGenerator {
+
+    private keyFileName: string[];
+
+    contents =
+        `{
+            "name": "hurley-network",
+            "version": "1.0.0",
+            "client": {
+                "tlsEnable": false,
+                "adminCredential": {
+                    "id": "admin",
+                    "password": "admin"
+                },
+                "enableAuthentication": true,
+                "organization": "${this.options.org.name}MSP",
+                "connection": {
+                    "timeout": {
+                        "peer": {
+                            "endorser": "300"
+                        },
+                        "orderer": "300"
+                    }
+                }
+            },
+            "channels": {
+                "ch1": {
+                    "peers": {
+                        "peer0.${this.options.org.name}.hurley.lab": {}
+                    },
+                    "connection": {
+                        "timeout": {
+                            "peer": {
+                                "endorser": "6000",
+                                "eventHub": "6000",
+                                "eventReg": "6000"
+                            }
+                        }
+                    }
+                }
+            },
+            "organizations": {
+                "${this.options.org.name}MSP": {
+                    "mspid": "${this.options.org.name}MSP",
+                    "adminPrivateKey": {
+                        "path": "/tmp/crypto/peerOrganizations/${this.options.org.name}.hurley.lab/users/Admin@${this.options.org.name}.hurley.lab/msp/keystore/${readdirSync(`${this.options.networkRootPath}/artifacts/crypto-config/peerOrganizations/${this.options.org.name}.hurley.lab/users/Admin@${this.options.org.name}.hurley.lab/msp/keystore/`)[0]}"
+                    },
+                    "peers": ["peer0.${this.options.org.name}.hurley.lab"],
+                    "signedCert": {
+                        "path": "/tmp/crypto/peerOrganizations/${this.options.org.name}.hurley.lab/users/Admin@${this.options.org.name}.hurley.lab/msp/signcerts/Admin@${this.options.org.name}.hurley.lab-cert.pem"
+                    }
+                }
+            },
+            "peers": {
+                "peer0.${this.options.org.name}.hurley.lab": {
+                    "tlsCACerts": {
+                        "path": "/tmp/crypto/peerOrganizations/${this.options.org.name}.hurley.lab/peers/peer0.${this.options.org.name}.hurley.lab/tls/ca.crt"
+                    },
+                    "url": "grpc://peer0.${this.options.org.name}.hurley.lab:7051"                }
+            }
+        }` ;
+
+    constructor(filename: string, path: string, private options: ExplorerConnectionProfileJSONGeneratorOptions) {
+        super(filename, path);
+        this.success = join(path, 'connection-profile.json.successful');
+    }
+}

--- a/src/generators/explorerConnectionProfile.ts
+++ b/src/generators/explorerConnectionProfile.ts
@@ -22,7 +22,7 @@ export class ExplorerConnectionProfileJSONGenerator extends BaseGenerator {
                     "id": "admin",
                     "password": "admin"
                 },
-                "enableAuthentication": true,
+                "enableAuthentication": false,
                 "organization": "${this.options.org.name}MSP",
                 "connection": {
                     "timeout": {
@@ -66,7 +66,9 @@ export class ExplorerConnectionProfileJSONGenerator extends BaseGenerator {
                     "tlsCACerts": {
                         "path": "/tmp/crypto/peerOrganizations/${this.options.org.name}.hurley.lab/peers/peer0.${this.options.org.name}.hurley.lab/tls/ca.crt"
                     },
-                    "url": "grpc://peer0.${this.options.org.name}.hurley.lab:7051"                }
+                    "url": "grpc://peer0.${this.options.org.name}.hurley.lab:7051",
+                    "eventUrl ":"grpc://peer0.${this.options.org.name}.hurley.lab:7052"
+                    }
             }
         }` ;
 

--- a/src/generators/explorerDockerCompose.yaml.ts
+++ b/src/generators/explorerDockerCompose.yaml.ts
@@ -1,0 +1,72 @@
+// tslint:disable:max-line-length
+import { BaseGenerator } from './base';
+import { join } from 'path';
+import { SysWrapper } from '../utils/sysWrapper';
+import { Organization } from '../models/organization';
+import { Channel } from '../models/channel';
+
+export class ExplorerDockerComposeYamlOptions {
+  networkRootPath: string;
+}
+export class ExplorerDockerComposeYamlGenerator extends BaseGenerator {
+
+  contents = `version: '2'
+networks:
+  net_hurley_dev_net:
+    external: true
+
+services:
+    explorerdb:
+        image: hyperledger/explorer-db:latest
+        container_name: explorerdb
+        hostname: explorerdb
+        environment:
+          - DATABASE_DATABASE=fabricexplorer
+          - DATABASE_USERNAME=hppoc
+          - DATABASE_PASSWORD=password
+        healthcheck:
+          test: "pg_isready -h localhost -p 5432 -q -U postgres"
+          interval: 30s
+          timeout: 10s
+          retries: 5
+        networks:
+          - net_hurley_dev_net
+
+    explorer:
+        image: hyperledger/explorer:latest
+        container_name: explorer
+        hostname: explorer
+        environment:
+          - DATABASE_HOST=explorerdb
+          - DATABASE_DATABASE=fabricexplorer
+          - DATABASE_USERNAME=hppoc
+          - DATABASE_PASSWD=password
+          - LOG_LEVEL_APP=debug
+          - LOG_LEVEL_DB=debug
+          - LOG_LEVEL_CONSOLE=debug
+          - LOG_CONSOLE_STDOUT=true
+          - DISCOVERY_AS_LOCALHOST=false
+        volumes:
+          - ${this.options.networkRootPath}/explorer/config.json:/opt/explorer/app/platform/fabric/config.json
+          - ${this.options.networkRootPath}/network-profiles/explorer-connection-profile.json:/opt/explorer/app/platform/fabric/connection-profile/connection-profile.json
+          - ${this.options.networkRootPath}/artifacts/crypto-config/:/tmp/crypto/
+          - ${this.options.networkRootPath}/explorer/wallet/:/opt/wallet/
+        ports:
+          - 8080:8080
+        depends_on:
+          explorerdb:
+            condition: service_healthy
+        networks:
+          - net_hurley_dev_net
+      
+volumes:
+  shared:
+
+  `;
+
+  success = join(this.path, 'dockercompose-explorer.yaml.successful');
+  constructor(filename: string, path: string, private options: ExplorerDockerComposeYamlOptions) {
+    super(filename, path);
+  }
+
+}

--- a/src/generators/explorerDockerCompose.yaml.ts
+++ b/src/generators/explorerDockerCompose.yaml.ts
@@ -52,7 +52,7 @@ services:
           - ${this.options.networkRootPath}/artifacts/crypto-config/:/tmp/crypto/
           - ${this.options.networkRootPath}/explorer/wallet/:/opt/wallet/
         ports:
-          - 8080:8080
+          - \${PORT}:8080
         depends_on:
           explorerdb:
             condition: service_healthy

--- a/src/generators/networkprofile.yaml.ts
+++ b/src/generators/networkprofile.yaml.ts
@@ -2,7 +2,6 @@
 import { BaseGenerator } from './base';
 import { join } from 'path';
 import { Organization } from '../models/organization';
-import { Channel } from '../models/channel';
 
 export class NetworkProfileYamlGeneratorOptions {
     org: Organization;
@@ -12,6 +11,7 @@ export class NetworkProfileYamlGeneratorOptions {
     insideDocker: boolean;
 }
 export class NetworkProfileYamlGenerator extends BaseGenerator {
+
     contents =
         `name: "${this.options.org.name}"
 version: "1.0"


### PR DESCRIPTION
Adds explorer command.
 
After bringing up a network using hurl new, just use when needed:
`hurl explorer`

the port can be defined using the -p option