### PR TITLE
feat: persistence volumes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,8 @@ hurl clean
 ### hurl new
 
 Create a new blockchain network in your computer. The first time you execute it, Hurley will check for Hyperledger Fabric's binaries and Container Images.
+It will store the container data holding up the blockchain information in a folder inside `<path>/data`. If this folder gets deleted, the blockchain information is gone.
+Hurley daletes this folder on every `hurl new`. If you don't want to delete it, run `hurl new --skip-cleanup`. It also gets deleted in the `hurl clean` command.
 
 ```bash
 # New project
@@ -56,6 +58,7 @@ hurl new
     [-c --channels <amount-of-channels>]
     [-p --path <path-to-install-the-network>]
     [-i --inside] # Whether or not the `hurl` command will runs inside the same Docker network where the blockchain was provisioned
+    [--skip-cleanup] Skips cleaning up the <path>/data folder
 ```
 
 ### hurl explorer
@@ -74,6 +77,7 @@ Clear your environment from all the components.
 
 ```bash
 hurl clean
+    [-p --path <path-to-install-the-network>]
     [-R --no-rmi] # Ask `hurl` to not delete the container images
 ```
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -14,14 +14,14 @@ function collect(val, memo) {
 
 const tasks = {
     async createNetwork(network?: any, organizations?: string, users?: string, channels?: string,
-        path?: string, explorer?:boolean, inside?: boolean, skipDownload?: boolean) {
-        return await CLI.createNetwork(network, organizations, users, channels, path, explorer, inside, skipDownload);
+        path?: string, explorer?:boolean, inside?: boolean, skipDownload?: boolean, skipCleanUp?: boolean) {
+        return await CLI.createNetwork(network, organizations, users, channels, path, explorer, inside, skipDownload, skipCleanUp);
     },
     async startupExplorer(port: string){
         return CLI.startupExplorer(port);
     },
-    async cleanNetwork(rmi: boolean) {
-        return await CLI.cleanNetwork(rmi);
+    async cleanNetwork(rmi: boolean, path?: string) {
+        return await CLI.cleanNetwork(rmi, path);
     },
     async installChaincode(chaincode: string, language: string, orgs?: string[], channel?: string,
         version?: string, params?: string, path?: string, ccPath?: string,
@@ -52,15 +52,16 @@ program
     .option('-e, --explorer', 'Uses hyperledger explorer')
     .option('-i, --inside', 'Optimized for running inside the docker compose network')
     .option('--skip-download', 'Skip downloading the Fabric Binaries and Docker images')
+    .option('--skip-cleanup', 'Skip deleting the <path>/data directory')
     // .option('-p, --peers <peers>', 'Peers per organization')
     .action(async (cmd: any) => {
         if (cmd) {
             await tasks.createNetwork(
                 cmd.network,
-                !cmd.organizations || (cmd.organizations <= 1) ? 1 : cmd.organizations,
+                !cmd.organizations ? 2 : cmd.organizations < 1 ? 1 : cmd.organizations,
                 !cmd.users || (cmd.users <= 1) ? 1 : cmd.users,
                 !cmd.channels || (cmd.channels <= 1) ? 1 : cmd.channels,
-                cmd.path, !!cmd.explorer ,!!cmd.inside, !!cmd.skipDownload
+                cmd.path, !!cmd.explorer ,!!cmd.inside, !!cmd.skipDownload, !!cmd.skipCleanUp
             );
         } else {
             await tasks.createNetwork();
@@ -79,8 +80,9 @@ program
 program
     .command('clean')
     .option('-R, --no-rmi', 'Do not remove docker images')
+    .option('-p, --path <path>', 'Path to deploy the network')
     .action(async (cmd: any) => {
-        await tasks.cleanNetwork(cmd.rmi); // if -R is not passed cmd.rmi is true
+        await tasks.cleanNetwork(cmd.rmi, cmd.path); // if -R is not passed cmd.rmi is true
     });
 
 program

--- a/src/generators/networkClean.sh.ts
+++ b/src/generators/networkClean.sh.ts
@@ -1,11 +1,10 @@
 // tslint:disable:max-line-length
 import { BaseGenerator } from './base';
 import { join } from 'path';
-import { Organization } from '../models/organization';
-import { Channel } from '../models/channel';
 
 export class NetworkCleanShOptions {
     removeImages: boolean;
+    networkRootPath: string;
 }
 export class NetworkCleanShGenerator extends BaseGenerator {
     success = join(this.path, 'networkclean.sh.successful');
@@ -16,6 +15,7 @@ set -e
 docker stop $(docker ps -a | awk '$2~/hyperledger/ {print $1}') 
 docker rm -f $(docker ps -a | awk '$2~/hyperledger/ {print $1}') $(docker ps -a | awk '{ print $1,$2 }' | grep dev-peer | awk '{print $1 }') || true
 ${this.options.removeImages ? `docker rmi -f $(docker images | grep dev-peer | awk '{print $3}') || true` : ``}
+rm -rf ${this.options.networkRootPath}/data
 `;
 
     constructor(filename: string, path: string, private options: NetworkCleanShOptions) {


### PR DESCRIPTION
In this PR, Hurley now persists the information in a `data` directory in the hyperledger folder

## Notes:
It will store the container data holding up the blockchain information in a folder inside `<path>/data`. If this folder gets deleted, the blockchain information is gone.
Hurley daletes this folder on every `hurl new`. If you don't want to delete it, run `hurl new --skip-cleanup`. It also gets deleted in the `hurl clean` command.